### PR TITLE
Allow to use Rouge 3.x

### DIFF
--- a/jekyll-commonmark-ghpages.gemspec
+++ b/jekyll-commonmark-ghpages.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "jekyll-commonmark", "~> 1"
   spec.add_runtime_dependency "commonmarker", "~> 0.17.6"
-  spec.add_runtime_dependency "rouge", "~> 3"
+  spec.add_runtime_dependency "rouge", ">= 2.0", "< 4.0"
 
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rake"

--- a/jekyll-commonmark-ghpages.gemspec
+++ b/jekyll-commonmark-ghpages.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "jekyll-commonmark", "~> 1"
   spec.add_runtime_dependency "commonmarker", "~> 0.17.6"
-  spec.add_runtime_dependency "rouge", "~> 2"
+  spec.add_runtime_dependency "rouge", "~> 3"
 
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Avoid dependencies issues with Jekyll:

```
Bundler could not find compatible versions for gem "rouge":
  In Gemfile:
    jekyll was resolved to 3.8.1, which depends on
      rouge (< 4, >= 1.7)
    jekyll-commonmark-ghpages (= 0.1.5) was resolved to 0.1.5, which depends on
      rouge (~> 2)
```