### PR TITLE
jekyll-commonmark is now processing the options in the initializer

### DIFF
--- a/jekyll-commonmark-ghpages.gemspec
+++ b/jekyll-commonmark-ghpages.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "jekyll-commonmark", "~> 1"
+  spec.add_runtime_dependency "jekyll-commonmark", "~> 1.2"
   spec.add_runtime_dependency "commonmarker", "~> 0.17.6"
   spec.add_runtime_dependency "rouge", "~> 2"
 

--- a/lib/jekyll-commonmark-ghpages.rb
+++ b/lib/jekyll-commonmark-ghpages.rb
@@ -81,13 +81,9 @@ class Jekyll::Converters::Markdown
   # final document.
   class CommonMarkGhPages < CommonMark
     def convert(content)
-      parse_options = (Set.new(@options) & CommonMarker::Config::Parse.keys).to_a
-      render_options = (Set.new(@options) & CommonMarker::Config::Render.keys).to_a
-      parse_options = :DEFAULT if parse_options.empty?
-      render_options = :DEFAULT if render_options.empty?
-      doc = CommonMarker.render_doc(content, parse_options, @extensions)
+      doc = CommonMarker.render_doc(content, @parse_options, @extensions)
       html = JekyllCommonMarkCustomRenderer.new(
-        :options => render_options,
+        :options => @render_options,
         :extensions => @extensions
       ).render(doc)
       html.gsub(/<br data-jekyll-commonmark-ghpages>/, "\n")


### PR DESCRIPTION
This commit https://github.com/jekyll/jekyll-commonmark/commit/2ea2d2e7222cdcc73f5f4fc990360c4e8fb9fbf2 on jekyll-commonmark v1.2.0 processes options in the initialise method rather than the convert method. This causes options to be ignored if bundler resolves jekyll-commonmark with this gem.