### PR TITLE
fixes typo and adds mention of other available extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ To specify extensions and options for use in converting Markdown to HTML, supply
 ```yaml
 commonmark:
   options: ["SMART", "FOOTNOTES"]
-  extensions: ["strikethrough", "autolink", "tables"]
+  extensions: ["strikethrough", "autolink", "table", "tagfilter"]
 ```


### PR DESCRIPTION
* `tables` should actually be `table`, it seems!
* added mention of `tagfilter` for documentation's sake