### PR TITLE
Docs: Typo in extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ To specify extensions and options for use in converting Markdown to HTML, supply
 ```yaml
 commonmark:
   options: ["SMART", "FOOTNOTES"]
-  extensions: ["strikethrough", "autolink", "tables"]
+  extensions: ["strikethrough", "autolink", "table"]
 ```


### PR DESCRIPTION
Avoid the following error message when using example config in README.

```
CommonMark: tables is not a valid extension
Valid extensions: table, strikethrough, autolink, tagfilter
```