### PR TITLE
Remove garbage on unknown lang

### DIFF
--- a/lib/jekyll-commonmark-ghpages.rb
+++ b/lib/jekyll-commonmark-ghpages.rb
@@ -46,8 +46,11 @@ class JekyllCommonMarkCustomRenderer < ::CommonMarker::HtmlRenderer
       out('><code>')
     else
       out("<pre#{sourcepos(node)}><code")
-      out(' class="language-', lang, '">') if lang
-      out('>')
+      if lang
+        out(' class="language-', lang, '">')
+      else
+        out('>')
+      end
     end
     out(escape_html(content))
     out('</code></pre>')


### PR DESCRIPTION
Input:

    ```unknown
    ```

Output:

    <pre><code class="language-unknown">></code></pre>

">" after "<code ...>" is garbage.