### PR TITLE
Update commonmarker to 0.23.6

### DIFF
--- a/jekyll-commonmark-ghpages.gemspec
+++ b/jekyll-commonmark-ghpages.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "jekyll", "~> 3.9.0"
   spec.add_runtime_dependency "jekyll-commonmark", "~> 1.4.0"
-  spec.add_runtime_dependency "commonmarker", "~> 0.23.4"
+  spec.add_runtime_dependency "commonmarker", "~> 0.23.6"
   spec.add_runtime_dependency "rouge", ">= 2.0", "< 4.0"
 
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Addresses CVE-2022-39209 as per https://github.com/gjtorikian/commonmarker/security/advisories/GHSA-4qw4-jpp4-8gvp