### PR TITLE
Security update: bump commonmarker to 0.23.7

### DIFF
--- a/jekyll-commonmark-ghpages.gemspec
+++ b/jekyll-commonmark-ghpages.gemspec
@@ -3,7 +3,7 @@
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-commonmark-ghpages"
   spec.summary       = "CommonMark generator for Jekyll"
-  spec.version       = "0.3.0"
+  spec.version       = "0.4.0"
   spec.authors       = ["GitHub, Inc."]
   spec.email         = "support@github.com"
   spec.homepage      = "https://github.com/github/jekyll-commonmark-ghpages"

--- a/jekyll-commonmark-ghpages.gemspec
+++ b/jekyll-commonmark-ghpages.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "jekyll", "~> 3.9.0"
   spec.add_runtime_dependency "jekyll-commonmark", "~> 1.4.0"
-  spec.add_runtime_dependency "commonmarker", "~> 0.23.6"
+  spec.add_runtime_dependency "commonmarker", "~> 0.23.7"
   spec.add_runtime_dependency "rouge", ">= 2.0", "< 4.0"
 
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Addresses https://github.com/gjtorikian/commonmarker/security/advisories/GHSA-636f-xm5j-pj9m