### PR TITLE
commonmarker to 0.23.10 security update

### DIFF
--- a/jekyll-commonmark-ghpages.gemspec
+++ b/jekyll-commonmark-ghpages.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "jekyll", "~> 3.9.0"
   spec.add_runtime_dependency "jekyll-commonmark", "~> 1.4.0"
-  spec.add_runtime_dependency "commonmarker", "~> 0.23.7"
+  spec.add_runtime_dependency "commonmarker", "~> 0.23.10"
   spec.add_runtime_dependency "rouge", ">= 2.0", "< 5.0"
 
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
https://github.com/gjtorikian/commonmarker/blob/v0.23.10/CHANGELOG.md

The `~> 0.23.7` is preventing dependabot from making a pull request for fixing the security issue.

```
updater | 2023/11/14 15:35:13 INFO <job_749817089> The latest possible version that can be installed is 0.17.13 because of the following conflicting dependency:
updater | 
updater |   github-pages (214) requires commonmarker (~> 0.17.6) via jekyll-commonmark-ghpages (0.1.6)
updater | 2023/11/14 15:35:13 INFO <job_749817089> The earliest fixed version is 0.23.10.
updater | 2023/11/14 15:35:13 INFO <job_749817089> Finished job processing
updater | 2023/11/14 15:35:13 INFO Results:
updater | Dependabot encountered '1' error(s) during execution, please check the logs for more details.
updater | +------------------------------+
updater | |            Errors            |
updater | +------------------------------+
updater | | security_update_not_possible |
updater | +------------------------------+
```